### PR TITLE
Export Script

### DIFF
--- a/doc/dxgridmaker.1
+++ b/doc/dxgridmaker.1
@@ -32,13 +32,22 @@ Set the input file name containing the RADIANCE primitives to
 Multiple files may be listed, however each file must have the '-f' option 
 preceding it.
 .TP
+.BI -i \ name
+Set the identifier sub-string that will be used to find the polygons for use
+in creating the analysis grid to 
+.IR name .
+Multiple identifier sub-strings may be listed, however each one must have 
+the '-i' option preceding it.  If neither this option nor the '-l' option is
+specified, all polygons will be used.
+.TP
 .BI -l \ name
 Set the layer name that will be used to find the polygons for use in creating
 the analysis grid to 
 .IR name .
 This layer name is equivalent to the modifier for the RADIANCE primitive of 
 interest.  Multiple layer names may be listed, however each name must have 
-the '-l' option preceding it.
+the '-l' option preceding it.  If neither this option nor the '-i' option is
+specified, all polygons will be used.
 .TP
 .BI -o \ val
 Set the overall offset to 

--- a/export.py
+++ b/export.py
@@ -12,7 +12,7 @@ parser.add_argument("--destination",
                     default = '../stadic-export',
                     help="directory to write exported files to")
 parser.add_argument("--git",
-                    default = 'git',
+                    default = '',
                     #'C:\\Program Files (x86)\\Git\\bin\\git.exe',
                     help="full path to git executable")
 parser.add_argument("--boost-prefix",
@@ -200,6 +200,12 @@ try:
         output = subprocess.Popen([gitcmd, 'rev-parse', '--short', 'HEAD'],
                                   stdout=subprocess.PIPE).communicate()[0]
         gitSha = output.decode('utf-8').strip()
+    else:
+        gitcmd = shutil.which('git')
+        if os.path.exists(gitcmd):
+            output = subprocess.Popen([gitcmd, 'rev-parse', '--short', 'HEAD'],
+                                      stdout=subprocess.PIPE).communicate()[0]
+            gitSha = output.decode('utf-8').strip()
 except:
     gitSha = 'UNKNOWN'
 
@@ -217,7 +223,7 @@ STADIC is based upon the Radiance ray-tracing software system. This is
 a subset created from git commit %s on %s with export.py.
 """ % (gitSha, datetime.datetime.now().strftime('%c'))
 
-fp = open(destination+'/README.txt', 'w')
+fp = open(destination+'/README.md', 'w')
 fp.write(readmeTxt)
 fp.close()
 print("Export complete.")

--- a/export.py
+++ b/export.py
@@ -12,12 +12,14 @@ parser.add_argument("--destination",
                     default = '../stadic-export',
                     help="directory to write exported files to")
 parser.add_argument("--git",
-                    default = 'C:\\Program Files (x86)\\Git\\bin\\git',
+                    default = 'C:\\Program Files (x86)\\Git\\bin\\git.exe',
                     help="full path to git executable")
 args = parser.parse_args()
 
 destination = args.destination
 gitcmd = args.git
+
+print(args.git)
 
 print('Exporting STADIC to "%s"...' % destination)
 
@@ -97,7 +99,7 @@ for file in (src+hdr):
 #
 # Copy utilities that are to be built
 #
-print("Copying utility source files")
+print("Copying utility source files...")
 os.makedirs(destination+'/utilities')
 cmakeTxt = """cmake_minimum_required(VERSION 2.8.11)
 
@@ -130,7 +132,7 @@ for file in src:
 #
 # Write top level files
 #
-print("Writing top level CMakeLists.txt and README files")
+print("Writing top level CMakeLists.txt and README files...")
 cmakeTxt = """cmake_minimum_required(VERSION 2.8.11)
 
 project(stadic)
@@ -210,4 +212,4 @@ a subset created from git commit %s on %s with export.py.
 fp = open(destination+'/README.txt', 'w')
 fp.write(readmeTxt)
 fp.close()
-print("Export complete")
+print("Export complete.")

--- a/export.py
+++ b/export.py
@@ -55,8 +55,8 @@ add_library(stadic_core SHARED ${HDRS} ${SRCS} ${DEP_SRCS})
 add_dependencies(stadic_core boost-geometry)"""
 
 filesBoth = [#'analemma',
-             'buildingcontrol',
-             'controlzone',
+             #'buildingcontrol',
+             #'controlzone',
              #'dayill',
              #'daylight',
              #'elecill',
@@ -64,7 +64,7 @@ filesBoth = [#'analemma',
              'filepath',
              'geometryprimitives',
              'gridmaker',
-             'jsonobjects',
+             #'jsonobjects',
              #'leakcheck',
              'logging',
              'materialprimitives',
@@ -74,11 +74,11 @@ filesBoth = [#'analemma',
              'radfiledata',
              'radparser',
              'radprimitive',
-             'spacecontrol',
-             'shadecontrol',
+             #'spacecontrol',
+             #'shadecontrol',
              'stadicprocess',
              #'weatherdata',
-             'windowgroup'
+             #'windowgroup'
              ]
 
 filesHeader = ['stadicapi.h', 'sharedvector.h']

--- a/export.py
+++ b/export.py
@@ -1,0 +1,182 @@
+import os
+import shutil
+import subprocess
+
+destination = '../stadic-export'
+
+if os.path.exists(destination):
+    exit('Destination path %s already exists!' % destination)
+
+os.makedirs(destination)
+#
+# Copy all dependencies
+#
+shutil.copytree('dependencies', destination + '/dependencies')
+#
+# Copy all docs?
+#
+
+#
+# Prune lib down to only the files we absolutely need
+#
+os.makedirs(destination+'/lib')
+cmakeTxt = """cmake_minimum_required(VERSION 2.8.11)
+
+project(lib)
+
+set(DEP_SRCS ../dependencies/jsoncpp/jsoncpp.cpp)
+
+set(SRCS %s)
+
+set(HDRS %s)
+
+add_library(stadic_core SHARED ${HDRS} ${SRCS} ${DEP_SRCS})
+add_dependencies(stadic_core boost-geometry)"""
+
+filesBoth = [#'analemma',
+             'buildingcontrol',
+             'controlzone',
+             #'dayill.cpp',
+             #'daylight',
+             #'elecill',
+             'functions',
+             'filepath',
+             'geometryprimitives',
+             'gridmaker',
+             'jsonobjects',
+             #'leakcheck',
+             'logging',
+             'materialprimitives',
+             #'metrics',
+             #'photosensor',
+             #'processshade',
+             'radfiledata',
+             'radparser',
+             'radprimitive',
+             'spacecontrol',
+             'shadecontrol',
+             'stadicprocess',
+             #'weatherdata',
+             'windowgroup'
+             ]
+
+filesHeader = ['stadicapi.h', 'sharedvector.h']
+
+src = ['%s.cpp' % el for el in filesBoth]
+
+hdr = filesHeader + ['%s.h' % el for el in filesBoth]
+
+# Write the CMake file
+fp = open(destination+'/lib/CMakeLists.txt', 'w')
+fp.write(cmakeTxt % (' '.join(src), ' '.join(hdr)))
+fp.close()
+
+# Copy the files
+for file in (src+hdr):
+    shutil.copy('lib/'+file, destination+'/lib/'+file)
+
+#
+# Copy utilities that are to be built
+#
+os.makedirs(destination+'/utilities')
+cmakeTxt = """cmake_minimum_required(VERSION 2.8.11)
+
+project(utilities)
+
+include_directories(../lib)
+
+"""
+
+exeTxt = """add_executable(%s %s.cpp)
+target_link_libraries(%s stadic_core)
+
+"""
+
+utils = ['dxgridmaker']
+
+for exe in utils:
+    cmakeTxt += (exeTxt % (exe, exe, exe))
+
+# Write the CMake file
+fp = open(destination+'/utilities/CMakeLists.txt', 'w')
+fp.write(cmakeTxt)
+fp.close()
+
+# Copy the files
+src = ['%s.cpp' % el for el in utils]
+for file in src:
+    shutil.copy('utilities/'+file, destination+'/utilities/'+file)
+
+#
+# Write top level files
+#
+cmakeTxt = """cmake_minimum_required(VERSION 2.8.11)
+
+project(stadic)
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+  # Apparently 4.6 is the earliest version supporting nullptr and range-based for
+  # https://gcc.gnu.org/projects/cxx0x.html
+  if(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "4.6.0")
+    message(FATAL_ERROR "g++ versions earlier than 4.6.0 are not supported")
+  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+elseif(MSVC)
+  # Visual Studio compiler check, totally borrowed from OpenStudio
+  # http://en.wikipedia.org/wiki/Visual_C%2B%2B#32-bit_and_64-bit_versions
+  if(${CMAKE_C_COMPILER_VERSION} VERSION_LESS "18.0.21005.1")
+    message(FATAL_ERROR "Visual Studio earlier than VS2013 is not supported")
+  endif()
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  # This check for clang seems to work, at least on Ubuntu. Not that much 
+  # else works on Ubuntu: had to add -I/usr/include/c++/4.8/ and 
+  # -I/usr/include/x86_64-linux-gnu/c++/4.8/ to get it to compile.
+  # Mac works as well!
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
+endif()
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+# Boost
+include(ExternalProject)
+ExternalProject_Add(boost-geometry
+  URL ${CMAKE_SOURCE_DIR}/dependencies/boost-geometry-1_57.tar.gz
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND "")
+set(Boost_INCLUDE_DIR ${CMAKE_BINARY_DIR}/boost-geometry-prefix/src/boost-geometry)
+include_directories(${Boost_INCLUDE_DIR})
+
+# JSON Dependency
+include_directories("dependencies/jsoncpp")
+
+add_subdirectory(lib)
+add_subdirectory(utilities)
+"""
+
+fp = open(destination+'/CMakeLists.txt', 'w')
+fp.write(cmakeTxt)
+fp.close()
+
+gitcmd = 'C:\\Program Files (x86)\\Git\\bin\\git'
+output = subprocess.Popen([gitcmd, 'rev-parse', '--short', 'HEAD'],
+                          stdout=subprocess.PIPE).communicate()[0]
+
+readmeTxt = """STADIC
+======
+
+Simulation Tool for Architectural Daylighting and Integrated Controls
+
+Developed by Rick Mistrick, Craig Casey, and Jason DeGraw at Penn State
+
+Description
+-----------
+
+STADIC is based upon the Radiance ray-tracing software system. This is
+a subset created from git commit %s with export.py.
+""" % output.decode('utf-8').strip()
+
+fp = open(destination+'/README.txt', 'w')
+fp.write(readmeTxt)
+fp.close()

--- a/export.py
+++ b/export.py
@@ -36,9 +36,6 @@ print("Copying dependencies...")
 # Copy all dependencies
 #
 shutil.copytree('dependencies', destination + '/dependencies')
-#
-# Copy all docs?
-#
 
 #
 # Prune lib down to only the files we absolutely need
@@ -139,6 +136,22 @@ for file in src:
     shutil.copy('utilities/'+file, destination+'/utilities/'+file)
 
 #
+# Look for documentation
+#
+print('Looking for documentation...')
+docs = [exe+'.1' for exe in utils]
+found = []
+for page in docs:
+    if os.path.exists('doc/'+page):
+        found.append(page)
+    else:
+        print('\tFailed to find '+page)
+if found:
+    os.makedirs(destination+'/doc')
+    for page in found:
+       shutil.copy('doc/'+page, destination+'/doc/'+page) 
+
+#
 # Write top level files
 #
 print("Writing top level CMakeLists.txt and README files...")
@@ -200,12 +213,6 @@ try:
         output = subprocess.Popen([gitcmd, 'rev-parse', '--short', 'HEAD'],
                                   stdout=subprocess.PIPE).communicate()[0]
         gitSha = output.decode('utf-8').strip()
-    else:
-        gitcmd = shutil.which('git')
-        if os.path.exists(gitcmd):
-            output = subprocess.Popen([gitcmd, 'rev-parse', '--short', 'HEAD'],
-                                      stdout=subprocess.PIPE).communicate()[0]
-            gitSha = output.decode('utf-8').strip()
 except:
     gitSha = 'UNKNOWN'
 

--- a/lib/filepath.cpp
+++ b/lib/filepath.cpp
@@ -36,7 +36,6 @@
 #include <iostream>
 #ifdef _MSC_VER
 #include <Windows.h>
-#include <direct.h>
 #else //POSIX
 #include <sys/stat.h>
 #include <string.h>
@@ -44,6 +43,7 @@
 #endif
 
 #ifdef _WIN32
+#include <direct.h>
 #define PATHSEPARATOR '\\'
 #define MKDIR _mkdir
 #else //POSIX

--- a/lib/gridmaker.cpp
+++ b/lib/gridmaker.cpp
@@ -306,7 +306,7 @@ bool GridMaker::parseRad(){
     std::vector<bool> firstPolygon;
 
     if (m_RadFile.geometry().empty()){
-        std::cerr<<"There are no polygons."<<std::endl;
+		STADIC_LOG(stadic::Severity::Error, "There are no polygons.");
         return false;
     }
 
@@ -598,7 +598,7 @@ bool GridMaker::testPoints(){
             return false;
         }
         if (m_PointSet[i].empty()){
-            std::cerr<<"The points array is empty."<<std::endl;
+			STADIC_LOG(stadic::Severity::Error, "The points array is empty.");
             return false;
         }
     }

--- a/lib/gridmaker.cpp
+++ b/lib/gridmaker.cpp
@@ -335,7 +335,7 @@ bool GridMaker::parseRad(){
         tempZ=tempZ/(radPoly->arg3().size()/3.0);
         boost::geometry::correct(tempPolygon);
         if (boost::geometry::is_valid(tempPolygon)){
-            //unite polygons that are the right layer name
+            //unite polygons that pass the test
             bool properName = filter(radPoly, names);
             int setPos;
             if (properName==true){
@@ -687,16 +687,6 @@ bool GridMaker::writeRadPoly(std::string file){
         oFile << std::endl;
     }
 
-    /*
-    for (int i=0;i<m_UnitedPolygon.size();i++){
-        oFile<<"floor\tpolygon\tfloor"<<i<<std::endl;
-        oFile<<"0\t0\t"<<(m_UnitedPolygon[i].outer().size()-1)*3<<std::endl;
-        for (int j=0;j<m_UnitedPolygon[i].outer().size()-1;j++){
-            oFile<<"\t"<<"\t"<<m_UnitedPolygon[i].outer()[j].get<0>()<<"\t"<<m_UnitedPolygon[i].outer()[j].get<1>()<<"\t0"<<std::endl;
-        }
-        oFile<<std::endl;
-    }
-    */
     oFile.close();
     return true;
 }

--- a/lib/gridmaker.cpp
+++ b/lib/gridmaker.cpp
@@ -306,7 +306,7 @@ bool GridMaker::parseRad(){
     std::vector<bool> firstPolygon;
 
     if (m_RadFile.geometry().empty()){
-		STADIC_LOG(stadic::Severity::Error, "There are no polygons.");
+        STADIC_LOG(stadic::Severity::Warning, "There are no polygons.");
         return false;
     }
 
@@ -594,11 +594,11 @@ bool GridMaker::testPoints(){
             x=x+spaceX();
         }
         if(m_PointSet.empty()){
-            STADIC_LOG(stadic::Severity::Error, "The points array has no pointsets.");
+            STADIC_LOG(stadic::Severity::Warning, "The points array has no pointsets.");
             return false;
         }
         if (m_PointSet[i].empty()){
-			STADIC_LOG(stadic::Severity::Error, "The points array is empty.");
+            STADIC_LOG(stadic::Severity::Warning, "The points array is empty.");
             return false;
         }
     }

--- a/lib/gridmaker.h
+++ b/lib/gridmaker.h
@@ -47,7 +47,7 @@ class STADIC_API GridMaker
 {
 public:
     GridMaker(std::vector<std::string> fileList);                                       //Constructor that takes a list of radiance geometry files
-    GridMaker(std::string file);                                                        //Constructor that takes a single radiane geometry file
+    GridMaker(std::string file);                                                        //Constructor that takes a single radiance geometry file
     //Setters
     //Points
 
@@ -87,6 +87,7 @@ public:
     bool viewPTS(std::string location, std::string vType);                              //Function to render a bmp of the points file and the layers chosen for the grid
     bool viewPTS(std::string location, std::string vType, std::string name);            //Function to render a bmp of the points file with a given name
     bool calcArea();                                                                      //Function to obtain the area of the polygons within the space
+    bool writeUnitedRadPoly(std::string file);  //!< Write out the united polygons
 
 private:
     //Points

--- a/lib/radfiledata.cpp
+++ b/lib/radfiledata.cpp
@@ -276,6 +276,12 @@ bool RadFileData::addPrimitive(std::shared_ptr<RadPrimitive> primitive)
     return true;
 }
 
+bool RadFileData::setPrimitives(const shared_vector<RadPrimitive> &primitives)
+{
+    m_primitives = primitives;
+    return true;
+}
+
 //Getters
 shared_vector<RadPrimitive> RadFileData::geometry() const
 {

--- a/lib/radfiledata.h
+++ b/lib/radfiledata.h
@@ -55,6 +55,7 @@ public:
 
     bool addPrimitive(RadPrimitive *primitive);                         //Function to add a rad primitive to the list of primitives
     bool addPrimitive(std::shared_ptr<RadPrimitive> primitive);  //!< Add a rad primitive to the list of primitives
+    bool setPrimitives(const shared_vector<RadPrimitive> &primitives);  //!< Replace the contents of the primitives list
 
     //Getters
     shared_vector<RadPrimitive> geometry() const;                       //Function to get just the geometry primitives as a vector

--- a/lib/stadicapi.h
+++ b/lib/stadicapi.h
@@ -46,4 +46,8 @@
 #pragma warning(disable: 4251)
 #endif
 
+#define VERSIONMAJOR 1
+#define VERSIONMINOR 0
+#define VERSIONPATCH 0
+
 #endif // STADICAPI_H

--- a/utilities/dxgridmaker.cpp
+++ b/utilities/dxgridmaker.cpp
@@ -213,7 +213,6 @@ int main (int argc, char *argv[])
     }
     if (geometryNamed==false){
         STADIC_LOG(stadic::Severity::Warning,"All geometry will be used to generate points.");
-        return EXIT_FAILURE;
     }
     grid.setSpaceX(sx);
     grid.setSpaceY(sy);

--- a/utilities/dxgridmaker.cpp
+++ b/utilities/dxgridmaker.cpp
@@ -248,13 +248,11 @@ int main (int argc, char *argv[])
             return EXIT_FAILURE;
         }
     }
-    /*
     if (!polyFile.empty()){
-        if (!grid.writeRadPoly(polyFile)){
+        if (!grid.writeUnitedRadPoly(polyFile)){
             return EXIT_FAILURE;
         }
     }
-    */
     if (!csvFile.empty()){
         if (!grid.writePTScsv(csvFile)){
             return EXIT_FAILURE;

--- a/utilities/dxgridmaker.cpp
+++ b/utilities/dxgridmaker.cpp
@@ -67,10 +67,10 @@ void usage()
         72, 15, true) << std::endl;
     std::cerr << stadic::wrapAtN("-l name        Set the layer name that will be used to find the polygons for use in"
         " creating the analysis grid to name.  Multiple layer names can be used, but each one must have a -l preceding"
-        " it.  This is a mandatory option.", 72, 15, true) << std::endl;
+        " it.", 72, 15, true) << std::endl;
     std::cerr << stadic::wrapAtN("-r name        Set the output file to name.  This file contains a space separated file"
         " in the following format per line:   x y z xd yd zd.", 72, 15, true) << std::endl;
-    std::cerr << stadic::wrapAtN("-rz val\tSet the angle of rotation to val.  A positive value should be used when the"
+    std::cerr << stadic::wrapAtN("-rz val        Set the angle of rotation to val.  A positive value should be used when the"
         " building (or space) is rotated ccw.  Setting the rotation allows the points to be aligned with the space.", 72, 15, true) << std::endl;
     std::cerr << stadic::wrapAtN("-t dist        Set the threshold distance.  Should the polygons be too small after the"
         " offset, and the length as well as width of the polygon are less than the threshold, those polygons will be"
@@ -212,7 +212,7 @@ int main (int argc, char *argv[])
         geometryNamed=true;
     }
     if (geometryNamed==false){
-        STADIC_LOG(stadic::Severity::Fatal,"Geometry must be specified with either the -l or -i options.");
+        STADIC_LOG(stadic::Severity::Warning,"All geometry will be used to generate points.");
         return EXIT_FAILURE;
     }
     grid.setSpaceX(sx);

--- a/utilities/dxgridmaker.cpp
+++ b/utilities/dxgridmaker.cpp
@@ -38,6 +38,7 @@
 void usage()
 {
     std::cerr << "Usage: dxgridmaker [OPTIONS]" << std::endl;
+    std::cerr << "Analysis point generator version " << VERSIONMAJOR << "." << VERSIONMINOR << "." << VERSIONPATCH << std::endl;
     std::cerr << stadic::wrapAtN("Generate a points file for use in Radiance analysis programs.  The program"
         " allows any number of polygons and any number of layer names to be used for the placement of points.  dxgridmaker"
         " joins all of the polygons and creates an array of points within the bounding rectangle and tests each"


### PR DESCRIPTION
@CraigCasey @rpg777 The export script now does a pretty good job of getting the minimal subset to support dxgridmaker. There are still some problems with using the subset as a subproject, but for now that can be worked around. To get a subset that is standalone:

```
python export.py
```

And to get one that will work as a subdirectory of Radiance:

```
python export.py --boost-prefix src/stadic/
```

We can fix that for real later. The git SHA stuff is pretty ugly, and may require Python3 to work well. The only remaining question is what to do about the docs. Any thoughts on that?
